### PR TITLE
Generate BQ schema descriptions from comments

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+const (
+	messagePath    = 4 // FileDescriptorProto.message_type
+	fieldPath      = 2 // DescriptorProto.field
+	subMessagePath = 3 // DescriptorProto.nested_type
+)
+
+// Comments is a map between path in FileDescriptorProto and leading/trailing comments for each field.
+type Comments map[string]string
+
+// ParseComments reads FileDescriptorProto and parses comments into a map.
+func ParseComments(fd *descriptor.FileDescriptorProto) Comments {
+	comments := make(Comments)
+
+	for _, loc := range fd.GetSourceCodeInfo().GetLocation() {
+		if !hasComment(loc) {
+			continue
+		}
+
+		path := loc.GetPath()
+		key := make([]string, len(path))
+		for idx, p := range path {
+			key[idx] = strconv.FormatInt(int64(p), 10)
+		}
+
+		comments[strings.Join(key, ".")] = buildComment(loc)
+	}
+
+	return comments
+}
+
+// Get returns comment for path or empty string if path has no comment.
+func (c Comments) Get(path string) string {
+	if val, ok := c[path]; ok {
+		return val
+	}
+
+	return ""
+}
+
+func hasComment(loc *descriptor.SourceCodeInfo_Location) bool {
+	if loc.GetLeadingComments() == "" && loc.GetTrailingComments() == "" {
+		return false
+	}
+
+	return true
+}
+
+func buildComment(loc *descriptor.SourceCodeInfo_Location) string {
+	comment := strings.TrimSpace(loc.GetLeadingComments()) + "\n\n" + strings.TrimSpace(loc.GetTrailingComments())
+	return strings.Trim(comment, "\n")
+}

--- a/comments_test.go
+++ b/comments_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+func TestParseComments(t *testing.T) {
+	leadingComment := "    leading comment"
+	trailingComment := "trailing comment"
+	subMessageFieldLeadingComment := "submessage field leading comment"
+
+	actual := ParseComments(
+		&descriptor.FileDescriptorProto{
+			SourceCodeInfo: &descriptor.SourceCodeInfo{
+				Location: []*descriptor.SourceCodeInfo_Location{
+					&descriptor.SourceCodeInfo_Location{
+						Path:             []int32{4, 0},
+						LeadingComments:  &leadingComment,
+						TrailingComments: &trailingComment,
+					},
+					&descriptor.SourceCodeInfo_Location{
+						Path:             []int32{4, 0, 3, 0, 2, 0},
+						LeadingComments:  &subMessageFieldLeadingComment,
+						TrailingComments: nil,
+					},
+				},
+			},
+		},
+	)
+
+	expected := Comments(map[string]string{
+		"4.0":         "leading comment\n\ntrailing comment",
+		"4.0.3.0.2.0": "submessage field leading comment",
+	})
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expectation: %v\n Actual: %v", actual, expected)
+	}
+}
+
+func TestParseCommentsWithoutComments(t *testing.T) {
+	actual := ParseComments(
+		&descriptor.FileDescriptorProto{
+			SourceCodeInfo: &descriptor.SourceCodeInfo{
+				Location: []*descriptor.SourceCodeInfo_Location{
+					&descriptor.SourceCodeInfo_Location{
+						Path: []int32{4, 0},
+					},
+				},
+			},
+		},
+	)
+
+	expected := Comments(map[string]string{})
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expectation: %v\n Actual: %v", actual, expected)
+	}
+}
+
+func TestCommentsGet(t *testing.T) {
+	comment := "comment"
+	comments := ParseComments(
+		&descriptor.FileDescriptorProto{
+			SourceCodeInfo: &descriptor.SourceCodeInfo{
+				Location: []*descriptor.SourceCodeInfo_Location{
+					&descriptor.SourceCodeInfo_Location{
+						Path:            []int32{4, 0},
+						LeadingComments: &comment,
+					},
+				},
+			},
+		},
+	)
+
+	actual := comments.Get("4.0")
+	expected := "comment"
+
+	if actual != expected {
+		t.Errorf("Expectation: %v\n Actual: %v", actual, expected)
+	}
+}

--- a/examples/foo.proto
+++ b/examples/foo.proto
@@ -10,12 +10,12 @@ message Bar {
   option (gen_bq_schema.table_name) = "bar_table";
 
   message Nested {
-    repeated int32 a = 1;
+    repeated int32 a = 1;  // Example description of Nested.a
   }
 
-  required int32 a = 1;
-  optional Nested b = 2;
-  repeated string c = 3;
+  required int32 a = 1;  // Example description of a
+  optional Nested b = 2;  // Example description of b
+  repeated string c = 3;  // Example description of c
 
   optional bool d = 4 [(gen_bq_schema.bigquery).ignore = true];
   optional uint64 e = 5 [

--- a/main.go
+++ b/main.go
@@ -62,9 +62,11 @@ type ProtoPackage struct {
 	parent   *ProtoPackage
 	children map[string]*ProtoPackage
 	types    map[string]*descriptor.DescriptorProto
+	comments map[string]Comments
+	path     map[string]string
 }
 
-func registerType(pkgName *string, msg *descriptor.DescriptorProto) {
+func registerType(pkgName *string, msg *descriptor.DescriptorProto, comments Comments, path string) {
 	pkg := globalPkg
 	if pkgName != nil {
 		for _, node := range strings.Split(*pkgName, ".") {
@@ -79,6 +81,8 @@ func registerType(pkgName *string, msg *descriptor.DescriptorProto) {
 					parent:   pkg,
 					children: make(map[string]*ProtoPackage),
 					types:    make(map[string]*descriptor.DescriptorProto),
+					comments: make(map[string]Comments),
+					path:     make(map[string]string),
 				}
 				pkg.children[node] = child
 			}
@@ -86,61 +90,65 @@ func registerType(pkgName *string, msg *descriptor.DescriptorProto) {
 		}
 	}
 	pkg.types[msg.GetName()] = msg
+	pkg.comments[msg.GetName()] = comments
+	pkg.path[msg.GetName()] = path
 }
 
-func (pkg *ProtoPackage) lookupType(name string) (*descriptor.DescriptorProto, bool) {
+func (pkg *ProtoPackage) lookupType(name string) (*descriptor.DescriptorProto, bool, Comments, string) {
 	if strings.HasPrefix(name, ".") {
 		return globalPkg.relativelyLookupType(name[1:len(name)])
 	}
 
 	for ; pkg != nil; pkg = pkg.parent {
-		if desc, ok := pkg.relativelyLookupType(name); ok {
-			return desc, ok
+		if desc, ok, comments, path := pkg.relativelyLookupType(name); ok {
+			return desc, ok, comments, path
 		}
 	}
-	return nil, false
+	return nil, false, Comments{}, ""
 }
 
-func relativelyLookupNestedType(desc *descriptor.DescriptorProto, name string) (*descriptor.DescriptorProto, bool) {
+func relativelyLookupNestedType(desc *descriptor.DescriptorProto, name string) (*descriptor.DescriptorProto, bool, string) {
 	components := strings.Split(name, ".")
+	path := ""
 componentLoop:
 	for _, component := range components {
-		for _, nested := range desc.GetNestedType() {
+		for nestedIndex, nested := range desc.GetNestedType() {
 			if nested.GetName() == component {
 				desc = nested
+				path = fmt.Sprintf("%s.%d.%d", path, subMessagePath, nestedIndex)
 				continue componentLoop
 			}
 		}
 		glog.Infof("no such nested message %s in %s", component, desc.GetName())
-		return nil, false
+		return nil, false, ""
 	}
-	return desc, true
+	return desc, true, strings.Trim(path, ".")
 }
 
-func (pkg *ProtoPackage) relativelyLookupType(name string) (*descriptor.DescriptorProto, bool) {
+func (pkg *ProtoPackage) relativelyLookupType(name string) (*descriptor.DescriptorProto, bool, Comments, string) {
 	components := strings.SplitN(name, ".", 2)
 	switch len(components) {
 	case 0:
 		glog.V(1).Info("empty message name")
-		return nil, false
+		return nil, false, Comments{}, ""
 	case 1:
 		found, ok := pkg.types[components[0]]
-		return found, ok
+		return found, ok, pkg.comments[components[0]], pkg.path[components[0]]
 	case 2:
 		glog.Infof("looking for %s in %s at %s (%v)", components[1], components[0], pkg.name, pkg)
 		if child, ok := pkg.children[components[0]]; ok {
-			found, ok := child.relativelyLookupType(components[1])
-			return found, ok
+			found, ok, comments, path := child.relativelyLookupType(components[1])
+			return found, ok, comments, path
 		}
 		if msg, ok := pkg.types[components[0]]; ok {
-			found, ok := relativelyLookupNestedType(msg, components[1])
-			return found, ok
+			found, ok, path := relativelyLookupNestedType(msg, components[1])
+			return found, ok, pkg.comments[components[0]], pkg.path[components[0]] + "." + path
 		}
 		glog.V(1).Infof("no such package nor message %s in %s", components[0], pkg.name)
-		return nil, false
+		return nil, false, Comments{}, ""
 	default:
 		glog.Fatal("not reached")
-		return nil, false
+		return nil, false, Comments{}, ""
 	}
 }
 
@@ -202,7 +210,7 @@ var (
 	}
 )
 
-func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, msg *descriptor.DescriptorProto) (*Field, error) {
+func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, msg *descriptor.DescriptorProto, comments Comments, path string) (*Field, error) {
 	field := &Field{
 		Name: desc.GetName(),
 	}
@@ -216,6 +224,10 @@ func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, m
 	field.Type, ok = typeFromFieldType[desc.GetType()]
 	if !ok {
 		return nil, fmt.Errorf("unrecognized field type: %s", desc.GetType().String())
+	}
+
+	if comment := comments.Get(path); comment != "" {
+		field.Description = comment
 	}
 
 	opts := desc.GetOptions()
@@ -251,12 +263,12 @@ func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, m
 		return field, nil
 	}
 
-	recordType, ok := curPkg.lookupType(desc.GetTypeName())
+	recordType, ok, comments, path := curPkg.lookupType(desc.GetTypeName())
 	if !ok {
 		return nil, fmt.Errorf("no such message type named %s", desc.GetTypeName())
 	}
 	var err error
-	field.Fields, err = convertMessageType(curPkg, recordType)
+	field.Fields, err = convertMessageType(curPkg, recordType, comments, path)
 	if err != nil {
 		return nil, err
 	}
@@ -268,12 +280,13 @@ func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, m
 	return field, nil
 }
 
-func convertMessageType(curPkg *ProtoPackage, msg *descriptor.DescriptorProto) (schema []*Field, err error) {
+func convertMessageType(curPkg *ProtoPackage, msg *descriptor.DescriptorProto, comments Comments, path string) (schema []*Field, err error) {
 	if glog.V(4) {
 		glog.Info("Converting message: ", proto.MarshalTextString(msg))
 	}
-	for _, fieldDesc := range msg.GetField() {
-		field, err := convertField(curPkg, fieldDesc, msg)
+	for fieldIndex, fieldDesc := range msg.GetField() {
+		fieldCommentPath := fmt.Sprintf("%s.%d.%d", path, fieldPath, fieldIndex)
+		field, err := convertField(curPkg, fieldDesc, msg, comments, fieldCommentPath)
 		if err != nil {
 			glog.Errorf("Failed to convert field %s in %s: %v", fieldDesc.GetName(), msg.GetName(), err)
 			return nil, err
@@ -294,8 +307,11 @@ func convertFile(file *descriptor.FileDescriptorProto) ([]*plugin.CodeGeneratorR
 		return nil, fmt.Errorf("no such package found: %s", file.GetPackage())
 	}
 
+	comments := ParseComments(file)
 	response := []*plugin.CodeGeneratorResponse_File{}
-	for _, msg := range file.GetMessageType() {
+	for msgIndex, msg := range file.GetMessageType() {
+		path := fmt.Sprintf("%d.%d", messagePath, msgIndex)
+
 		options := msg.GetOptions()
 		if options == nil {
 			continue
@@ -313,7 +329,7 @@ func convertFile(file *descriptor.FileDescriptorProto) ([]*plugin.CodeGeneratorR
 		}
 
 		glog.V(2).Info("Generating schema for a message type ", msg.GetName())
-		schema, err := convertMessageType(pkg, msg)
+		schema, err := convertMessageType(pkg, msg, comments, path)
 		if err != nil {
 			glog.Errorf("Failed to convert %s: %v", name, err)
 			return nil, err
@@ -348,9 +364,9 @@ func convert(req *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, e
 
 	res := &plugin.CodeGeneratorResponse{}
 	for _, file := range req.GetProtoFile() {
-		for _, msg := range file.GetMessageType() {
+		for msgIndex, msg := range file.GetMessageType() {
 			glog.V(1).Infof("Loading a message type %s from package %s", msg.GetName(), file.GetPackage())
-			registerType(file.Package, msg)
+			registerType(file.Package, msg, ParseComments(file), fmt.Sprintf("%d.%d", messagePath, msgIndex))
 		}
 	}
 	for _, file := range req.GetProtoFile() {


### PR DESCRIPTION
This allows us to automatically convert all the comments in the `proto` files to BQ schema description columns.

The main work for this was done by someone else in their own fork:
- https://github.com/chuhlomin/protoc-gen-bq-schema

However, the changes couldn't automatically be brought over as that
fork has diverged from ours.

Thus I brought over the relevant changes manually.